### PR TITLE
Fix once function typing

### DIFF
--- a/scheduler/asyncio/scheduler.py
+++ b/scheduler/asyncio/scheduler.py
@@ -448,7 +448,7 @@ class Scheduler(BaseScheduler):
         *,
         args: tuple[Any] = None,
         kwargs: Optional[dict[str, Any]] = None,
-        tags: Optional[list[str]] = None,
+        tags: Optional[set[str]] = None,
         alias: str = None,
     ) -> Job:
         r"""

--- a/scheduler/base/scheduler.py
+++ b/scheduler/base/scheduler.py
@@ -148,7 +148,7 @@ class BaseScheduler(ABC):  # NOTE maybe a typing Protocol class is better than a
         *,
         args: Optional[tuple[Any]] = None,
         kwargs: Optional[dict[str, Any]] = None,
-        tags: Optional[list[str]] = None,
+        tags: Optional[set[str]] = None,
     ) -> BaseJob:
         """Schedule a oneshot |BaseJob|."""
 


### PR DESCRIPTION
This is to fix a bug that appears when calling once with tags=list[str] instead of set[str].


```

    if not self._scheduler.get_jobs(tags={key1}):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/mambaforge/base/envs/stock-ai/lib/python3.11/site-packages/scheduler/asyncio/scheduler.py", line 245, in get_jobs
    return cast(set[Job], select_jobs_by_tag(cast(set[BaseJob], self.jobs), tags, any_tag))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/mambaforge/base/envs/stock-ai/lib/python3.11/site-packages/scheduler/base/scheduler.py", line 49, in select_jobs_by_tag
    return {job for job in jobs if tags <= job.tags}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/mambaforge/base/envs/stock-ai/lib/python3.11/site-packages/scheduler/base/scheduler.py", line 49, in <setcomp>
    return {job for job in jobs if tags <= job.tags}
                                   ^^^^^^^^^^^^^^^^
TypeError: '<=' not supported between instances of 'set' and 'list'
```