### PR TITLE
Fixes once args typing

### DIFF
--- a/scheduler/asyncio/scheduler.py
+++ b/scheduler/asyncio/scheduler.py
@@ -449,7 +449,7 @@ class Scheduler(BaseScheduler[Job, Callable[..., Coroutine[Any, Any, None]]]):
         timing: TimingOnceUnion,
         handle: Callable[..., Coroutine[Any, Any, None]],
         *,
-        args: Optional[tuple[Any]] = None,
+        args: Optional[tuple[Any, ...]] = None,
         kwargs: Optional[dict[str, Any]] = None,
         tags: Optional[Iterable[str]] = None,
         alias: Optional[str] = None,


### PR DESCRIPTION
To fix mypy[arg-type](https://mypy.readthedocs.io/en/stable/_refs.html#code-arg-type)
